### PR TITLE
Add missing wrapper to form fields

### DIFF
--- a/resources/views/components/html-forms.blade.php
+++ b/resources/views/components/html-forms.blade.php
@@ -5,5 +5,7 @@
     {!! $hidden !!}
   </div>
 
-  {!! $slot !!}
+  <div class="hf-fields-wrap">
+    {!! $slot !!}
+  </div>
 </form>


### PR DESCRIPTION
The form fields must be wrapped in a `<div class="hf-fields-wrap">...</div>`, otherwise the form hiding / redirection upon successful submission will fail (the HTML Forms JS searches for `.hf-fields-wrap` in order to hide the fields.

Fixes issue #7.