### PR TITLE
chore(docs): clarify variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You will find the generated form view in `resources/views/forms/contact-us.blade
 
 When HTML Forms processes "Form Actions" – it simply fetches each input name to create the usable variables.
 
-That being said, the default view would provide `[NAME]` and `[EMAILADDRESS]`.
+That being said, the default view would provide `[name]` and `[emailAddress]`.
 
 #### Error Messages
 


### PR DESCRIPTION
Variables created use the same case as written in the field name. This updates the readme so it references the correct case of variables created from the default view.

This is important as the the case needs to be correct to use these in form actions.